### PR TITLE
improvement: finish /count endpoint and associated parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "fun-with-nom"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fun-with-nom"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A repo and playground for learning the Nom crate"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I understand how to compose the simple building block parsers.
 
 ## Challenges to Overcome
 
-I don't understand yet, how to use combinators correctly.
+I'm beginning to understand combinators. There is now a `/count` endpoint which accepts a plain text string of any length. The endpoint responds with the word count. Nom is leveraged here via calling a parser which returns the text input as a vector of words. The `.len()` method is then called to get the word count.
 
 ## Nom Resources
 

--- a/src/lib/errors/error.rs
+++ b/src/lib/errors/error.rs
@@ -1,0 +1,4 @@
+// src/lib/errors/error.rs
+
+// dependencies
+

--- a/src/lib/errors/mod.rs
+++ b/src/lib/errors/mod.rs
@@ -1,0 +1,5 @@
+// src/lib/routes/mod.rs
+
+// pub mod error;
+
+// pub use error::*;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,6 +1,7 @@
 // src/lib/lib.rs
 
+pub mod errors;
+pub mod parser;
 pub mod routes;
-pub mod utilities;
 
-pub use utilities::*;
+pub use parser::*;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -1,0 +1,57 @@
+// src/lib/parser.rs
+
+// dependences
+use nom::bytes::complete::tag;
+use nom::character::complete::alpha0;
+use nom::multi::separated_list0;
+use nom::IResult;
+
+// a parser which will find any sequence of alphabetic characters: a-z, A-Z
+fn parse_word(input: &str) -> IResult<&str, &str> {
+    alpha0(input)
+}
+
+// a parsser which will recognize a white space
+fn parse_space(input: &str) -> IResult<&str, &str> {
+    tag(" ")(input)
+}
+
+// a combinator which will take a sentence as input and convert it into a vector of all the individual words
+pub fn parse_sentence(input: &str) -> IResult<&str, Vec<&str>> {
+    separated_list0(parse_space, parse_word)(input)
+}
+
+// unit tests for each parser and combinator
+#[cfg(test)]
+
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse_word() {
+        let input = "test";
+        let result = parse_word(input);
+        assert_eq!(result, Ok(("", "test")));
+    }
+
+    #[test]
+    fn test_parse_space() {
+        let input = " test";
+        let result = parse_space(input);
+        assert_eq!(result, Ok(("test", " ")));
+    }
+
+    #[test]
+    fn test_parse_sentence() {
+        let input = "The quick brown fox jumped over the lazy dog";
+        let result = parse_sentence(input);
+        assert_eq!(
+            result,
+            Ok((
+                "",
+                vec!("The", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog")
+            ))
+        );
+    }
+}

--- a/src/lib/routes/count.rs
+++ b/src/lib/routes/count.rs
@@ -1,21 +1,28 @@
 // src/lib/routes/count.rs
 
 // dependencies
-use actix_web::{post, Responder, Result, web};
+use crate::parser::parse_sentence;
+use actix_web::{post, web, Result, Responder};
 use serde::Serialize;
+
+// for future use in in improving the error handling and getting rid of the unwrap below
+// type NomError = nom::Err<nom::error::Error<&str>>;
 
 // struct type for the JSON response body
 #[derive(Clone, Debug, Serialize)]
-struct Count {
-  result: String,
+struct WordCount {
+    result: usize,
 }
 
-// count endpoint handler; will eventually return the word count, right now just echos back plaintext input in JSON format
+// count endpoint handler; takes the plaintext input from the request body, uses a Nom parser to return a vector containing all the words,
+// then gets the length of the vector to get the word count
 #[post("/count")]
 async fn count(body: String) -> Result<impl Responder> {
-    let count = Count {
-      result: body.to_string()
+    let (_, words) = parse_sentence(&body).unwrap();    // the parse_sentence function gives back the remainder after the Nom parsing, we destructure to get rid of it
+
+    let word_count = WordCount {
+        result: words.len(),
     };
 
-    Ok(web::Json(count))
+    Ok(web::Json(word_count))
 }

--- a/src/lib/utilities.rs
+++ b/src/lib/utilities.rs
@@ -1,3 +1,0 @@
-// src/lib/utilities.rs
-
-// dependences


### PR DESCRIPTION
The /count endpoint is now complete. It demonstrates use of the separated_pair Nom combinator, which breaks the words of a sentence apart and saves them in a vector, the length of which gives the word count.